### PR TITLE
Make Server-Port Configurable

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -24,6 +25,7 @@ func main() {
 
 	// Create a new Gin router.
 	router := gin.Default()
+	serverPort := strconv.Itoa(int(settings.Port))
 
 	// Load HTML templates depending on whether the application is running inside a container.
 	_, container := os.LookupEnv("CONTAINER")
@@ -38,18 +40,18 @@ func main() {
 	// Register all application routes, including the static file serving route for locales.
 	web.RegisterRoutes(router)
 
-	printWelcomeBanner()
+	printWelcomeBanner(serverPort)
 	log.Println("--- Fail2Ban-UI started in", gin.Mode(), "mode ---")
-	log.Println("Server listening on port :8080.")
+	log.Println("Server listening on port", serverPort, ".")
 
 	// Start the server on port 8080.
-	if err := router.Run(":8080"); err != nil {
+	if err := router.Run(":", serverPort); err != nil {
 		log.Fatalf("Server crashed: %v", err)
 	}
 }
 
 // printWelcomeBanner prints a cool Tux banner with startup info.
-func printWelcomeBanner() {
+func printWelcomeBanner(appPort string) {
 	greeting := getGreeting()
 	const tuxBanner = `
       .--.
@@ -62,13 +64,13 @@ func printWelcomeBanner() {
 
 Fail2Ban UI - A Swissmade Management Interface
 ----------------------------------------------
-Developers: https://swissmakers.ch
-Mode: %s
-Listening on: http://0.0.0.0:8080
+Developers:   https://swissmakers.ch
+Mode:         %s
+Listening on: http://0.0.0.0:%s
 ----------------------------------------------
 
 `
-	fmt.Printf(tuxBanner, greeting, gin.Mode())
+	fmt.Printf(tuxBanner, greeting, gin.Mode(), appPort)
 }
 
 // getGreeting returns a friendly greeting based on the time of day.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -45,8 +45,8 @@ func main() {
 	log.Println("Server listening on port", serverPort, ".")
 
 	// Start the server on port 8080.
-	if err := router.Run(":", serverPort); err != nil {
-		log.Fatalf("Server crashed: %v", err)
+	if err := router.Run(":" + serverPort); err != nil {
+		log.Fatalf("Could not start server: %v\n", err)
 	}
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -40,6 +40,7 @@ type SMTPSettings struct {
 // AppSettings holds the main UI settings and Fail2ban configuration
 type AppSettings struct {
 	Language       string       `json:"language"`
+	Port           int          `json:"port"`
 	Debug          bool         `json:"debug"`
 	ReloadNeeded   bool         `json:"reloadNeeded"`
 	AlertCountries []string     `json:"alertCountries"`
@@ -57,10 +58,11 @@ type AppSettings struct {
 
 // init paths to key-files
 const (
-	settingsFile = "fail2ban-ui-settings.json" // this is relative to where the app was started
-	jailFile     = "/etc/fail2ban/jail.local"  // Path to jail.local (to override conf-values from jail.conf)
-	jailDFile    = "/etc/fail2ban/jail.d/ui-custom-action.conf"
-	actionFile   = "/etc/fail2ban/action.d/ui-custom-action.conf"
+	settingsFile    = "fail2ban-ui-settings.json" // this is relative to where the app was started
+	defaultjailFile = "/etc/fail2ban/jail.conf"
+	jailFile        = "/etc/fail2ban/jail.local" // Path to jail.local (to override conf-values from jail.conf)
+	jailDFile       = "/etc/fail2ban/jail.d/ui-custom-action.conf"
+	actionFile      = "/etc/fail2ban/action.d/ui-custom-action.conf"
 )
 
 // in-memory copy of settings
@@ -96,6 +98,9 @@ func setDefaults() {
 
 	if currentSettings.Language == "" {
 		currentSettings.Language = "en"
+	}
+	if currentSettings.Port == 0 {
+		currentSettings.Port = 8080
 	}
 	if currentSettings.AlertCountries == nil {
 		currentSettings.AlertCountries = []string{"ALL"}

--- a/internal/fail2ban/client.go
+++ b/internal/fail2ban/client.go
@@ -37,7 +37,7 @@ func GetJails() ([]string, error) {
 	cmd := exec.Command("fail2ban-client", "status")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("could not get jail information. is fail2ban running? error: %v", err)
+		return nil, fmt.Errorf("error: unable to retrieve jail information. is your fail2ban service running? details: %v", err)
 	}
 
 	var jails []string


### PR DESCRIPTION
This pull request introduces the ability to configure the server port for the application, enhancing its flexibility for deployment in different environments. Additionally, it addresses a couple of issues related to the startup process and error messaging.

Commits:
Add hook, if no jail.local was precreated and fix bug on server start

Introduced logic to create jail.local from jail.conf if it doesn't exist, ensuring a smoother startup process.
Change fail2ban service not running error

Improved error messaging for when the Fail2Ban service is not running, providing clearer guidance to the user.
Code Changes:
cmd/server/main.go:

Made the server port configurable by reading from the settings and updating the server startup routine.
Updated log messages and welcome banner to reflect the configurable port.
internal/config/settings.go:

Introduced a new field Port in AppSettings for port configuration.
Added default value logic for the port if not specified.
internal/fail2ban/client.go: