### PR TITLE
Fail2ban Callback URL update also on ssh/agent servers replace base64 payload bash -c with a stdin via here-doc to prevent false phrasings

### DIFF
--- a/internal/fail2ban/manager.go
+++ b/internal/fail2ban/manager.go
@@ -131,6 +131,17 @@ func (m *Manager) UpdateActionFiles(ctx context.Context) error {
 	return lastErr
 }
 
+// UpdateActionFileForServer updates the action file for a specific server by ID.
+func (m *Manager) UpdateActionFileForServer(ctx context.Context, serverID string) error {
+	m.mu.RLock()
+	conn, ok := m.connectors[serverID]
+	m.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("connector for server %s not found or not enabled", serverID)
+	}
+	return updateConnectorAction(ctx, conn)
+}
+
 // updateConnectorAction updates the action file for a specific connector.
 func updateConnectorAction(ctx context.Context, conn Connector) error {
 	switch c := conn.(type) {


### PR DESCRIPTION
fix Fail2ban Callback URL update also on ssh/agent servers
replace base64 payload bash -c with a stdin via here-doc to prevent false phrasings