### PR TITLE
feat: Multi-arch build support

### DIFF
--- a/.gitea/workflows/build-harbor.yml
+++ b/.gitea/workflows/build-harbor.yml
@@ -11,6 +11,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      - name: Set up Podman buildx
+        run: |
+          podman buildx create --use --name multiarch-builder || true
+          podman buildx inspect --bootstrap
+
       - name: Login to Swissmakers Registry
         if: ${{ secrets.HARBOR_REGISTRY && secrets.HARBOR_USERNAME && secrets.HARBOR_PASSWORD }}
         env:
@@ -21,21 +31,16 @@ jobs:
           mkdir -p "$HOME/.config/containers"
           echo "$ROBOT_PASS" | podman login --username "$ROBOT_USER" --password-stdin "$REGISTRY"
 
-      - name: Build & tag for Swissmakers Registry
+      - name: Build & push multi-arch image to Swissmakers Registry
         env:
           REG:  ${{ secrets.HARBOR_REGISTRY }}
           PROJ: ${{ secrets.HARBOR_PROJECT }}
         run: |
-          podman build -t $REG/$PROJ/fail2ban-ui:${{ github.sha }} .
-          podman tag  $REG/$PROJ/fail2ban-ui:${{ github.sha }} $REG/$PROJ/fail2ban-ui:latest
-
-      - name: Push to Swissmakers Registry
-        env:
-          REG:  ${{ secrets.HARBOR_REGISTRY }}
-          PROJ: ${{ secrets.HARBOR_PROJECT }}
-        run: |
-          podman push $REG/$PROJ/fail2ban-ui:${{ github.sha }}
-          podman push $REG/$PROJ/fail2ban-ui:latest
+          podman buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -t $REG/$PROJ/fail2ban-ui:${{ github.sha }} \
+            -t $REG/$PROJ/fail2ban-ui:latest \
+            --push .
 
       - name: Login to Docker Hub
         if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
@@ -45,7 +50,7 @@ jobs:
         run: |
           echo "$DH_TOKEN" | podman login docker.io --username "$DH_USER" --password-stdin
 
-      - name: Re-tag the build image for Docker Hub
+      - name: Re-tag & push multi-arch image to Docker Hub
         if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
         env:
           REG:  ${{ secrets.HARBOR_REGISTRY }}
@@ -53,14 +58,10 @@ jobs:
           DH_NS: ${{ secrets.DOCKERHUB_USERNAME }}
           DH_REPO: fail2ban-ui
         run: |
+          podman pull $REG/$PROJ/fail2ban-ui:${{ github.sha }} --all
+          
           podman tag $REG/$PROJ/fail2ban-ui:${{ github.sha }} docker.io/$DH_NS/$DH_REPO:${{ github.sha }}
-          podman tag $REG/$PROJ/fail2ban-ui:${{ github.sha }} docker.io/$DH_NS/$DH_REPO:latest
-
-      - name: Push to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
-        env:
-          DH_NS: ${{ secrets.DOCKERHUB_USERNAME }}
-          DH_REPO: fail2ban-ui
-        run: |
+          podman tag $REG/$PROJ/fail2ban-ui:latest docker.io/$DH_NS/$DH_REPO:latest
+          
           podman push docker.io/$DH_NS/$DH_REPO:${{ github.sha }}
           podman push docker.io/$DH_NS/$DH_REPO:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 # =========================================
 FROM golang:1.24 AS builder
 
+ARG TARGETARCH
+
 WORKDIR /app
 
 # Copy module files and download dependencies first
@@ -13,7 +15,10 @@ RUN go mod download
 COPY . .
 
 # Build Go application (as static binary)
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o fail2ban-ui ./cmd/server/main.go
+RUN CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=${TARGETARCH} \
+    go build -o fail2ban-ui ./cmd/server/main.go
 
 # ===================================
 #  STAGE 2: Standalone UI Version


### PR DESCRIPTION
This pull request updates the build pipeline and Dockerfile to enable multi-architecture (multi-arch) image builds and pushes for both the Swissmakers Registry and Docker Hub. The changes streamline the workflow to support both `amd64` and `arm64` platforms, improving deployment flexibility and compatibility.

Closes #47 