### PR TITLE
feat(api): cap banned IPs per jail in /api/summary response

### DIFF
--- a/internal/fail2ban/connector_global.go
+++ b/internal/fail2ban/connector_global.go
@@ -19,9 +19,27 @@ package fail2ban
 
 import (
 	"context"
+	"os"
 	"sort"
+	"strconv"
 	"sync"
 )
+
+// summaryMaxBannedIPs caps the number of banned IPs returned per jail in
+// the /api/summary response. The accurate TotalBanned count is always
+// preserved; only the BannedIPs slice is truncated. Set the
+// FAIL2BAN_UI_SUMMARY_MAX_IPS env var to 0 to disable the cap.
+var summaryMaxBannedIPs = func() int {
+	v := os.Getenv("FAIL2BAN_UI_SUMMARY_MAX_IPS")
+	if v == "" {
+		return 100
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 100
+	}
+	return n
+}()
 
 // =========================================================================
 //  Types
@@ -93,10 +111,14 @@ func collectJailInfos(ctx context.Context, jails []string, getBannedIPs bannedIP
 				results <- jailResult{err: err}
 				return
 			}
+			totalBanned := len(ips)
+			if summaryMaxBannedIPs > 0 && totalBanned > summaryMaxBannedIPs {
+				ips = ips[:summaryMaxBannedIPs]
+			}
 			results <- jailResult{
 				jail: JailInfo{
 					JailName:    j,
-					TotalBanned: len(ips),
+					TotalBanned: totalBanned,
 					BannedIPs:   ips,
 					Enabled:     true,
 				},


### PR DESCRIPTION
## Why

The dashboard's `/api/summary` handler enumerates every active jail and returns the **full banned-IP list** for each via `collectJailInfos`. On hosts with large jails this becomes a hard scaling problem.

In our environment we have ~17 active jails and one of them (`nginx-property-scraper`) holds **4,500+ active bans** at any given moment due to a sustained MLS-scraping campaign. With those numbers, `/api/summary` takes **3+ minutes** to respond. Every reasonable HTTP gateway/proxy returns 504 long before that — for us it was AWS ALB's default 60s `idle_timeout`. Result: the dashboard's "Loading summary data…" panel never resolves and the JS console shows `SyntaxError: Unexpected token '<', '<html><h'... is not valid JSON` (the parser choking on the gateway's HTML 504).

## What this changes

Adds a small cap on `BannedIPs` per jail in the JSON returned by `/api/summary`. The accurate `TotalBanned` count is always preserved — only the `BannedIPs` slice is truncated.

- Default cap: **100** IPs per jail
- Configurable via env var `FAIL2BAN_UI_SUMMARY_MAX_IPS`
- Set to `0` to disable the cap and restore current behaviour (full list)

## Why 100 is enough for the dashboard

`pkg/web/static/js/dashboard.js`'s `renderBannedIPs` shows only the **first 5 IPs per jail** by default (`maxVisible = 5`); the rest are hidden behind a "show more" toggle. 100 leaves comfortable headroom for the expanded view without forcing the backend to materialise tens of thousands of strings into a single JSON response.

## Reproduction

```sh
# inside a container with a large jail
$ fail2ban-client status nginx-property-scraper | head -10
Status for the jail: nginx-property-scraper
   |- Currently banned:	4632
   ...
$ time curl -s http://localhost:8080/api/summary?serverId=local >/dev/null
# >180s, often times out at the gateway with 504
```

After this patch (with default `FAIL2BAN_UI_SUMMARY_MAX_IPS=100`):

```sh
$ time curl -s http://localhost:8080/api/summary?serverId=local | jq '.jails[] | {jailName, totalBanned, returnedIPs: (.bannedIPs | length)}'
# responds well under 1s
{ "jailName": "nginx-property-scraper", "totalBanned": 4632, "returnedIPs": 100 }
...
```

## Trade-offs and follow-ups

- Users who genuinely need the entire ban list in `/api/summary` can keep current behaviour via `FAIL2BAN_UI_SUMMARY_MAX_IPS=0`.
- A cleaner long-term direction is to expose the full per-jail list via a separate paginated endpoint (e.g. `/api/jails/:jail/banned?limit=&offset=`) and have the dashboard fetch it on-demand when the user expands a jail. Happy to follow up with that as a separate PR if you'd like — keeping this one minimal so it can land quickly.

## Diff

`+23 / -1` lines, single file `internal/fail2ban/connector_global.go`.

Thanks for fail2ban-ui — it's been a great fit for our infrastructure.

Made with [Cursor](https://cursor.com)